### PR TITLE
update: opening keyboard in pin views now moves the button, placeholder text in generate view is now grayed out

### DIFF
--- a/app/src/main/java/org/satochip/seedkeeper/ui/components/generate/InputField.kt
+++ b/app/src/main/java/org/satochip/seedkeeper/ui/components/generate/InputField.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.satochip.seedkeeper.R
+import org.satochip.seedkeeper.ui.theme.SatoActiveTracer
 import org.satochip.seedkeeper.ui.theme.SatoPurple
 
 @Composable
@@ -110,7 +111,7 @@ fun InputField(
                                 modifier = Modifier.align(Alignment.CenterStart),
                                 text = stringResource(id = placeHolder),
                                 style = TextStyle(
-                                    color = textColor,
+                                    color = Color.LightGray,
                                     fontSize = 16.sp,
                                     lineHeight = 21.sp,
                                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/org/satochip/seedkeeper/ui/components/shared/InputPinField.kt
+++ b/app/src/main/java/org/satochip/seedkeeper/ui/components/shared/InputPinField.kt
@@ -48,8 +48,6 @@ fun InputPinField(
     val passwordVisibility = remember {
         mutableStateOf(visualTransformation != PasswordVisualTransformation())
     }
-    val keyboardController = LocalSoftwareKeyboardController.current
-
 
     val trailingIcon: (@Composable () -> Unit)? = @Composable {
         Image(
@@ -84,9 +82,6 @@ fun InputPinField(
             onValueChange = {
                 curValue.value = it
             },
-            keyboardActions = KeyboardActions(
-                onDone = { keyboardController?.hide() }
-            ),
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Done,
                 autoCorrect = false,

--- a/app/src/main/java/org/satochip/seedkeeper/ui/components/shared/RememberImeState.kt
+++ b/app/src/main/java/org/satochip/seedkeeper/ui/components/shared/RememberImeState.kt
@@ -1,0 +1,33 @@
+package org.satochip.seedkeeper.ui.components.shared
+
+import android.view.ViewTreeObserver
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+@Composable
+fun rememberImeState(): State<Boolean> {
+    val imeState = remember {
+        mutableStateOf(false)
+    }
+    val view = LocalView.current
+
+    DisposableEffect(view) {
+        val listener = ViewTreeObserver.OnGlobalLayoutListener {
+            val isKeyboardOpen = ViewCompat.getRootWindowInsets(view)
+                ?.isVisible(WindowInsetsCompat.Type.ime()) ?: true
+            imeState.value = isKeyboardOpen
+        }
+
+        view.viewTreeObserver.addOnGlobalLayoutListener(listener)
+        onDispose {
+            view.viewTreeObserver.removeOnGlobalLayoutListener(listener)
+        }
+    }
+    return imeState
+}

--- a/app/src/main/java/org/satochip/seedkeeper/ui/views/editpincode/EditPinCodeView.kt
+++ b/app/src/main/java/org/satochip/seedkeeper/ui/views/editpincode/EditPinCodeView.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -29,6 +30,7 @@ import org.satochip.seedkeeper.data.TypeOfSecret
 import org.satochip.seedkeeper.ui.components.shared.HeaderAlternateRow
 import org.satochip.seedkeeper.ui.components.shared.InputPinField
 import org.satochip.seedkeeper.ui.components.shared.SatoButton
+import org.satochip.seedkeeper.ui.components.shared.rememberImeState
 
 @Composable
 fun EditPinCodeView(
@@ -49,6 +51,7 @@ fun EditPinCodeView(
     val curPinCode = remember {
         mutableStateOf("")
     }
+    val imeState = rememberImeState()
 
     when (pinCodeStatus.value) {
         PinCodeStatus.CURRENT_PIN_CODE -> {
@@ -127,56 +130,85 @@ fun EditPinCodeView(
                     curValue = curValue,
                     placeHolder = placeholderText
                 )
+                if (imeState.value) {
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    EditPinButtons(
+                        pinCodeStatus = pinCodeStatus,
+                        curPinCode = curPinCode,
+                        curValue = curValue,
+                        buttonText = buttonText,
+                        onClick = onClick
+                    )
+                }
             }
             Column(
                 modifier = Modifier
                     .fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                if (pinCodeStatus.value == PinCodeStatus.WRONG_PIN_CODE) {
-                    //Back
-                    SatoButton(
-                        onClick = {
-                            pinCodeStatus.value = PinCodeStatus.INPUT_NEW_PIN_CODE
-                        },
-                        buttonColor = Color.Transparent,
-                        textColor = Color.Black,
-                        text = R.string.restartTheSetup
-                    )
-                }
-                SatoButton(
-                    modifier = Modifier,
-                    onClick = {
-                        when (pinCodeStatus.value) {
-                            PinCodeStatus.CURRENT_PIN_CODE -> {
-                                pinCodeStatus.value = onClick(CardInformationItems.EDIT_PIN_CODE, curValue.value)
-                            }
-                            PinCodeStatus.INPUT_NEW_PIN_CODE -> {
-                                curPinCode.value = curValue.value
-                                pinCodeStatus.value = PinCodeStatus.CONFIRM_PIN_CODE
-                                curValue.value = ""
-                            }
-                            PinCodeStatus.CONFIRM_PIN_CODE -> {
-                                if (curPinCode.value == curValue.value) {
-                                    onClick(CardInformationItems.CONFIRM, curValue.value)
-                                } else {
-                                    curValue.value = ""
-                                    pinCodeStatus.value = PinCodeStatus.WRONG_PIN_CODE
-                                }
-                            }
-                            PinCodeStatus.WRONG_PIN_CODE -> {
-                                if (curPinCode.value == curValue.value) {
-                                    onClick(CardInformationItems.CONFIRM, curValue.value)
-                                } else {
-                                    curValue.value = ""
-                                }
-                            }
-                        }
-                    },
-                    text = buttonText.value
+                EditPinButtons(
+                    pinCodeStatus = pinCodeStatus,
+                    curPinCode = curPinCode,
+                    curValue = curValue,
+                    buttonText = buttonText,
+                    onClick = onClick
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }
+}
+
+@Composable
+fun EditPinButtons(
+    pinCodeStatus: MutableState<PinCodeStatus>,
+    curPinCode: MutableState<String>,
+    curValue: MutableState<String>,
+    buttonText: MutableState<Int>,
+    onClick: (CardInformationItems, String?) -> PinCodeStatus
+    ) {
+
+    if (pinCodeStatus.value == PinCodeStatus.WRONG_PIN_CODE) {
+        //Back
+        SatoButton(
+            onClick = {
+                pinCodeStatus.value = PinCodeStatus.INPUT_NEW_PIN_CODE
+            },
+            buttonColor = Color.Transparent,
+            textColor = Color.Black,
+            text = R.string.restartTheSetup
+        )
+    }
+    SatoButton(
+        modifier = Modifier,
+        onClick = {
+            when (pinCodeStatus.value) {
+                PinCodeStatus.CURRENT_PIN_CODE -> {
+                    pinCodeStatus.value = onClick(CardInformationItems.EDIT_PIN_CODE, curValue.value)
+                }
+                PinCodeStatus.INPUT_NEW_PIN_CODE -> {
+                    curPinCode.value = curValue.value
+                    pinCodeStatus.value = PinCodeStatus.CONFIRM_PIN_CODE
+                    curValue.value = ""
+                }
+                PinCodeStatus.CONFIRM_PIN_CODE -> {
+                    if (curPinCode.value == curValue.value) {
+                        onClick(CardInformationItems.CONFIRM, curValue.value)
+                    } else {
+                        curValue.value = ""
+                        pinCodeStatus.value = PinCodeStatus.WRONG_PIN_CODE
+                    }
+                }
+                PinCodeStatus.WRONG_PIN_CODE -> {
+                    if (curPinCode.value == curValue.value) {
+                        onClick(CardInformationItems.CONFIRM, curValue.value)
+                    } else {
+                        curValue.value = ""
+                    }
+                }
+            }
+        },
+        text = buttonText.value
+    )
 }

--- a/app/src/main/java/org/satochip/seedkeeper/ui/views/generate/GenerateView.kt
+++ b/app/src/main/java/org/satochip/seedkeeper/ui/views/generate/GenerateView.kt
@@ -310,6 +310,7 @@ fun GenerateView(
                                             TypeOfSecret.MNEMONIC_PHRASE -> {
                                                 generateStatus.value =
                                                     GenerateStatus.MNEMONIC_PHRASE
+                                                passwordOptions.value.passwordLength = 12
                                             }
 
                                             TypeOfSecret.LOGIN_PASSWORD -> {

--- a/app/src/main/java/org/satochip/seedkeeper/ui/views/pincode/PinCodeView.kt
+++ b/app/src/main/java/org/satochip/seedkeeper/ui/views/pincode/PinCodeView.kt
@@ -1,6 +1,5 @@
 package org.satochip.seedkeeper.ui.views.pincode
 
-import android.widget.Space
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -27,6 +26,7 @@ import org.satochip.seedkeeper.data.CardInformationItems
 import org.satochip.seedkeeper.ui.components.shared.HeaderAlternateRow
 import org.satochip.seedkeeper.ui.components.shared.InputPinField
 import org.satochip.seedkeeper.ui.components.shared.SatoButton
+import org.satochip.seedkeeper.ui.components.shared.rememberImeState
 
 @Composable
 fun PinCodeView(
@@ -40,6 +40,7 @@ fun PinCodeView(
     val curValue = remember {
         mutableStateOf("")
     }
+    val imeState = rememberImeState()
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -94,6 +95,19 @@ fun PinCodeView(
                     curValue = curValue,
                     placeHolder = placeholderText
                 )
+                if (imeState.value) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SatoButton(
+                        modifier = Modifier,
+                        onClick = {
+                            if (isMultiStep)
+                                onClick(CardInformationItems.NEXT, curValue.value)
+                            else
+                                onClick(CardInformationItems.CONFIRM, curValue.value)
+                        },
+                        text = if (isMultiStep) R.string.next else R.string.confirm
+                    )
+                }
             }
             Column {
                 SatoButton(


### PR DESCRIPTION
Done:

- Pin and edit pin view will have their button moved when keyboard opens,
- generate view mnemonic button will generate defaultly 12 words instead of four,
- placeholder text in generate view is grayed out instead of being white
